### PR TITLE
chore: refine github action self-check

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -80,6 +80,11 @@ branches:
           - tests (windows-latest, 3.7, x64, local)
           - tests (windows-latest, 3.8, x64, local)
           - tests (windows-latest, 3.x, x64, local)
+          # GitHub Action self-test
+          - Self-test / self-check (test/vectors/exclude/pass.toml)
+          - Self-test / self-check (test/vectors/include/pass.toml)
+          - Self-test / self-check (test/vectors/many/pass.toml)
+          - Self-test / self-check (test/vectors/output-check/pass.toml)
   - name: master
     protection:
       required_pull_request_reviews: null
@@ -108,3 +113,8 @@ branches:
           - tests (windows-latest, 3.7, x64, local)
           - tests (windows-latest, 3.8, x64, local)
           - tests (windows-latest, 3.x, x64, local)
+          # GitHub Action self-test
+          - Self-test / self-check (test/vectors/exclude/pass.toml)
+          - Self-test / self-check (test/vectors/include/pass.toml)
+          - Self-test / self-check (test/vectors/many/pass.toml)
+          - Self-test / self-check (test/vectors/output-check/pass.toml)

--- a/.github/workflows/ci_self-test.yaml
+++ b/.github/workflows/ci_self-test.yaml
@@ -17,7 +17,7 @@ jobs:
           - test/vectors/output-check/pass.toml
     steps:
       - uses: actions/checkout@v2
-      - uses: mattsb42-meta/not-grep@master
+      - uses: ./
         with:
           debug: true
           config-file: ${{ matrix.test-file }}


### PR DESCRIPTION
* use local commit contents rather than upstream master to actually test this commit
* require self-check checks in branch protection rules