### PR TITLE
chore: use setuptools less than 81.0.0

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -70,21 +70,25 @@ branches:
           - analysis (lint)
           - prettier
           # Linux
-          - tests (ubuntu-latest, 3.7, x64, local)
-          - tests (ubuntu-latest, 3.8, x64, local)
-          - tests (ubuntu-latest, 3.x, x64, local)
-          # MacOS
-          - tests (macos-latest, 3.7, x64, local)
-          - tests (macos-latest, 3.8, x64, local)
-          - tests (macos-latest, 3.x, x64, local)
+          - tests (ubuntu-latest, 3.10, x64, local)
+          - tests (ubuntu-latest, 3.11, x64, local)
+          - tests (ubuntu-latest, 3.12, x64, local)
+          # MacOS x64
+          - tests (macos-latest, 3.10, x64, local)
+          - tests (macos-latest, 3.11, x64, local)
+          - tests (macos-latest, 3.12, x64, local)
+          # MacOS x86
+          - tests (macos-latest, 3.10, x86, local)
+          - tests (macos-latest, 3.11, x86, local)
+          - tests (macos-latest, 3.12, x86, local)
           # Windows x86
-          - tests (windows-latest, 3.7, x86, local)
-          - tests (windows-latest, 3.8, x86, local)
-          - tests (windows-latest, 3.x, x86, local)
+          - tests (windows-latest, 3.10, x86, local)
+          - tests (windows-latest, 3.11, x86, local)
+          - tests (windows-latest, 3.12, x86, local)
           # Windows x64
-          - tests (windows-latest, 3.7, x64, local)
-          - tests (windows-latest, 3.8, x64, local)
-          - tests (windows-latest, 3.x, x64, local)
+          - tests (windows-latest, 3.10, x64, local)
+          - tests (windows-latest, 3.11, x64, local)
+          - tests (windows-latest, 3.12, x64, local)
           # GitHub Action self-test
           - self-check (test/vectors/exclude/pass.toml)
           - self-check (test/vectors/include/pass.toml)
@@ -106,21 +110,25 @@ branches:
           - analysis (lint)
           - prettier
           # Linux
-          - tests (ubuntu-latest, 3.7, x64, local)
-          - tests (ubuntu-latest, 3.8, x64, local)
-          - tests (ubuntu-latest, 3.x, x64, local)
-          # MacOS
-          - tests (macos-latest, 3.7, x64, local)
-          - tests (macos-latest, 3.8, x64, local)
-          - tests (macos-latest, 3.x, x64, local)
+          - tests (ubuntu-latest, 3.10, x64, local)
+          - tests (ubuntu-latest, 3.11, x64, local)
+          - tests (ubuntu-latest, 3.12, x64, local)
+          # MacOS x64
+          - tests (macos-latest, 3.10, x64, local)
+          - tests (macos-latest, 3.11, x64, local)
+          - tests (macos-latest, 3.12, x64, local)
+          # MacOS x86
+          - tests (macos-latest, 3.10, x86, local)
+          - tests (macos-latest, 3.11, x86, local)
+          - tests (macos-latest, 3.12, x86, local)
           # Windows x86
-          - tests (windows-latest, 3.7, x86, local)
-          - tests (windows-latest, 3.8, x86, local)
-          - tests (windows-latest, 3.x, x86, local)
+          - tests (windows-latest, 3.10, x86, local)
+          - tests (windows-latest, 3.11, x86, local)
+          - tests (windows-latest, 3.12, x86, local)
           # Windows x64
-          - tests (windows-latest, 3.7, x64, local)
-          - tests (windows-latest, 3.8, x64, local)
-          - tests (windows-latest, 3.x, x64, local)
+          - tests (windows-latest, 3.10, x64, local)
+          - tests (windows-latest, 3.11, x64, local)
+          - tests (windows-latest, 3.12, x64, local)
           # GitHub Action self-test
           - self-check (test/vectors/exclude/pass.toml)
           - self-check (test/vectors/include/pass.toml)

--- a/.github/workflows/ci_self-test.yaml
+++ b/.github/workflows/ci_self-test.yaml
@@ -16,7 +16,7 @@ jobs:
           - test/vectors/many/pass.toml
           - test/vectors/output-check/pass.toml
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - uses: ./
         with:
           debug: true

--- a/.github/workflows/ci_static-analysis.yaml
+++ b/.github/workflows/ci_static-analysis.yaml
@@ -14,8 +14,8 @@ jobs:
           - mypy
           - bandit
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: 3.x
       - run: |
@@ -28,7 +28,7 @@ jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
       - name: prettify
         run: ./.github/prettify.sh check

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -14,7 +14,7 @@ jobs:
           - windows-latest
           - macos-latest
         python:
-          - 3.10
+          - "3.10"
           - 3.x
         architecture:
           - x64

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -13,9 +13,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macos-latest
-        python:
-          - "3.10"
-          - 3.x
+        python: ["3.10", "3.11", "3.12"]
         architecture:
           - x64
           - x86
@@ -28,8 +26,8 @@ jobs:
           - os: macos-latest
             architecture: x86
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v1
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.architecture }}

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -23,14 +23,17 @@ jobs:
         exclude:
           - os: ubuntu-latest
             architecture: x86
-          - os: macos-latest
-            architecture: x86
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-python@v6
+        if: ${{matrix.os != 'macos-latest'}}
         with:
           python-version: ${{ matrix.python }}
           architecture: ${{ matrix.architecture }}
+      - uses: actions/setup-python@v6
+        if: ${{matrix.os == 'macos-latest'}}
+        with:
+          python-version: ${{ matrix.python }}
       - run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r ci-requirements.txt

--- a/.github/workflows/ci_tests.yaml
+++ b/.github/workflows/ci_tests.yaml
@@ -14,8 +14,7 @@ jobs:
           - windows-latest
           - macos-latest
         python:
-          - 3.7
-          - 3.8
+          - 3.10
           - 3.x
         architecture:
           - x64

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,5 +1,6 @@
 # pylint: disable=invalid-name
 """Sphinx configuration."""
+
 import io
 import os
 import re
@@ -29,7 +30,7 @@ def get_version():
     return _release
 
 
-project = u"not_grep"
+project = "not_grep"
 version = get_version()
 release = get_release()
 
@@ -55,7 +56,7 @@ templates_path = ["_templates"]
 source_suffix = ".rst"  # The suffix of source filenames.
 master_doc = "index"  # The master toctree document.
 
-copyright = u"%s, Amazon" % datetime.now().year  # pylint: disable=redefined-builtin
+copyright = "%s, Amazon" % datetime.now().year  # pylint: disable=redefined-builtin
 
 # List of directories, relative to source directory, that shouldn't be searched
 # for source files.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -56,7 +56,7 @@ templates_path = ["_templates"]
 source_suffix = ".rst"  # The suffix of source filenames.
 master_doc = "index"  # The master toctree document.
 
-copyright = "%s, Amazon" % datetime.now().year  # pylint: disable=redefined-builtin
+copyright = f"{datetime.now().year}, Amazon"  # pylint: disable=redefined-builtin
 
 # List of directories, relative to source directory, that shouldn't be searched
 # for source files.
@@ -70,7 +70,7 @@ autodoc_member_order = "bysource"
 
 html_theme = "sphinx_rtd_theme"
 html_static_path = ["_static"]
-htmlhelp_basename = "%sdoc" % project
+htmlhelp_basename = f"{project}doc"
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {"python": ("http://docs.python.org/", None)}

--- a/examples/test/test_make_tests.py
+++ b/examples/test/test_make_tests.py
@@ -1,4 +1,5 @@
 """Placeholder module to remind you to write tests."""
+
 import pytest
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 click>=7.1.1
 attrs>=19.3.0
 toml>=0.10.0
-setuptools
+setuptools<=81.0.0

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 """not-grep."""
+
 import io
 import os
 import re

--- a/src/not_grep/__init__.py
+++ b/src/not_grep/__init__.py
@@ -43,7 +43,7 @@ def cli(config: Optional[str], verbose: int):
         except KeyError as error:
             raise click.exceptions.BadOptionUsage(
                 option_name="config",
-                message=f"Config file must provided or set through environment '{_CONFIG_FILE}' variable",
+                message=f"Config file must provided or set through environment '{_CONFIG_FILE}' variable",  # noqa C0301
             ) from error
         if not os.path.isfile(config):
             raise click.BadOptionUsage(

--- a/src/not_grep/__init__.py
+++ b/src/not_grep/__init__.py
@@ -1,4 +1,5 @@
 """``not-grep`` is kind of like grep, but not quite the same."""
+
 import os
 from typing import Optional
 

--- a/src/not_grep/_config.py
+++ b/src/not_grep/_config.py
@@ -34,7 +34,7 @@ class Config:
     def parse(cls, config_file_path: str) -> "Config":
         """Parse a config file and load the requested checks."""
         # 1. Parse config file
-        with open(config_file_path, "r") as config_file:
+        with open(config_file_path, "r", encoding="utf-8") as config_file:
             parsed = toml.load(config_file)
         # 2. For each checker:
         all_checks = {}

--- a/src/not_grep/_config.py
+++ b/src/not_grep/_config.py
@@ -1,4 +1,5 @@
 """Parse a config file."""
+
 import glob
 from typing import Callable, Iterable, Mapping, Sequence
 

--- a/src/not_grep/_plugin_loader.py
+++ b/src/not_grep/_plugin_loader.py
@@ -16,11 +16,17 @@ def _load_plugins() -> Dict[str, Callable[[str, str], bool]]:
 
     for entry_point in pkg_resources.iter_entry_points(PLUGIN_ENTRY_POINT):
         if entry_point.name in plugins:
+            existing_dist = plugins[entry_point.name].dist
+            current_dist = entry_point.dist
+
+            existing_name = existing_dist.project_name if existing_dist else "unknown"
+            current_name = current_dist.project_name if current_dist else "unknown"
+
             raise click.exceptions.UsageError(
-                f"Found conflicting entry points for '{entry_point.name}'"  # type: ignore
-                "\n Registered entry points found in projects:"
-                f"\n  {plugins[entry_point.name].dist.project_name}"
-                f"\n  {entry_point.dist.project_name}"
+                f"Found conflicting entry points for '{entry_point.name}'"
+                "Registered entry points found in projects:"
+                f"{existing_name}"
+                f"{current_name}"
             )
         plugins[entry_point.name] = entry_point
 

--- a/src/not_grep/_plugin_loader.py
+++ b/src/not_grep/_plugin_loader.py
@@ -1,4 +1,5 @@
 """Load not-grep checker plugins."""
+
 from typing import Callable, Dict
 
 import click

--- a/src/not_grep/_run_checks.py
+++ b/src/not_grep/_run_checks.py
@@ -1,4 +1,5 @@
 """Run the checks."""
+
 import shutil
 
 import click

--- a/src/not_grep/checkers.py
+++ b/src/not_grep/checkers.py
@@ -1,4 +1,5 @@
 """Built-in checkers."""
+
 __all__ = ("include", "exclude", "output_test")
 
 

--- a/test/functional/test_cli.py
+++ b/test/functional/test_cli.py
@@ -1,4 +1,5 @@
 """Black-box functional tests for the CLI."""
+
 import os
 from functools import partial
 

--- a/test/unit/test_checkers.py
+++ b/test/unit/test_checkers.py
@@ -1,4 +1,5 @@
 """Unit tests for ``not_grep.checkers``."""
+
 import pytest
 
 from not_grep import checkers
@@ -14,13 +15,11 @@ EXCLUDE_PATTERN = "exclude pattern"
 @pytest.fixture
 def source_file(tmpdir) -> str:
     source = tmpdir.join("source")
-    source.write(
-        f"""{PREFIX_PATTERN}
+    source.write(f"""{PREFIX_PATTERN}
     more data
     {INCLUDE_PATTERN}
     more data
-    {SUFFIX_PATTERN}"""
-    )
+    {SUFFIX_PATTERN}""")
     return str(source)
 
 

--- a/test/unit/test_config.py
+++ b/test/unit/test_config.py
@@ -1,4 +1,5 @@
 """Unit tests for ``not_grep._config``."""
+
 from typing import Dict
 
 import pytest

--- a/test/unit/test_plugin_loader.py
+++ b/test/unit/test_plugin_loader.py
@@ -1,4 +1,5 @@
 """Unit tests for ``not_grep._plugin_loader``."""
+
 from collections import namedtuple
 
 import click

--- a/tox.ini
+++ b/tox.ini
@@ -36,7 +36,7 @@ commands = not-grep --config {toxinidir}/.github/not-grep.toml
 #########
 
 [testenv:base-command]
-commands = pytest --basetemp={envtmpdir} -l --cov not_grep {posargs}
+commands = pytest -l --cov not_grep {posargs}
 
 [testenv]
 passenv =

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,7 @@ sitepackages = False
 # Always upgrade pip to latest
 download = True
 deps = -rtest/requirements.txt
+allowlist_externals = mkdir, rm
 commands =
     # Local tests: no network access required
     local: {[testenv:base-command]commands} test/ -m local

--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,7 @@ deps =
     coverage~=4.0
     mypy>=0.650
     mypy_extensions
+    types-toml
 commands =
     python -m mypy \
         --linecoverage-report build \

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,7 @@ commands = pytest --basetemp={envtmpdir} -l --cov not_grep {posargs}
 [testenv]
 passenv =
     # Pass through PyPI variable
-    PYPI_SECRET_ARN TWINE_PASSWORD
+    PYPI_SECRET_ARN, TWINE_PASSWORD
 sitepackages = False
 # Always upgrade pip to latest
 download = True


### PR DESCRIPTION
setuptools removed `pkg_resources`
https://setuptools.pypa.io/en/stable/history.html#v82-0-0
dowgrading setuptools to less than or equal to 81.0.0 should do the trick

currently blocking our [CI](https://github.com/aws/aws-database-encryption-sdk-dynamodb/actions/runs/21836571819/job/63010734199) since it installs the latest version of setuptools and this 
project uses pkg_resources